### PR TITLE
Support third party licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Firebase libraries.
 ## Getting Started
 
 The plugins contained in this project are meant to work with the Google Play
-services SDK.  See https://developers.google.com/android/guides/overview to
+services SDK. See https://developers.google.com/android/guides/overview to
 get started.
 
 ## Contents
@@ -23,3 +23,8 @@ Helps apps to display open source software licenses and notices.
 
 Required for firebase applications on android, converts google-services.json to a resource file for use by the app, and references the code in strict-version-matcher.
 
+## Manually add licenses
+
+Create a `third_party_licenses` directory in the root directory of your project. Then add any license as a text file.
+The name of the file is used in the list activity, so best to avoid any file extensions like `.txt`. The contents of
+the file are shown in the license activity itself.

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
@@ -106,7 +106,7 @@ class LicensesTask extends DefaultTask {
             }
         }
 
-        for (filename in thirdPartyLicenses) {
+        for (filename in thirdPartyLicenses.sort{it.getName().toLowerCase()}) {
             addLicensesFromFile(filename)
         }
 

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -58,6 +59,9 @@ class LicensesTask extends DefaultTask {
 
     @InputFile
     File dependenciesJson
+
+    @InputFiles
+    public File[] thirdPartyLicenses
 
     @OutputDirectory
     File outputDir
@@ -100,6 +104,10 @@ class LicensesTask extends DefaultTask {
             } else {
                 addLicensesFromPom(group, name, version)
             }
+        }
+
+        for (filename in thirdPartyLicenses) {
+            addLicensesFromFile(filename)
         }
 
         writeMetadata()
@@ -227,6 +235,11 @@ class LicensesTask extends DefaultTask {
             String nodeUrl = rootNode.licenses.license.url
             appendLicense(licenseKey, nodeUrl.getBytes(UTF_8))
         }
+    }
+
+    private void addLicensesFromFile(File filename) {
+        String licenseName = filename.getName()
+        appendLicense(licenseName, filename.getBytes())
     }
 
     private File resolvePomFileArtifact(String group, String name, String version) {

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
@@ -37,13 +37,17 @@ class OssLicensesPlugin implements Plugin<Project> {
         def licensesMetadataFile = new File(outputDir,
                 "third_party_license_metadata")
         def licenseTask = project.tasks.create("generateLicenses", LicensesTask)
+        def thirdPartyLicensesDir = new File(project.rootProject.projectDir, "third_party_licenses")
+        def thirdPartyLicenses = thirdPartyLicensesDir.exists() ? thirdPartyLicensesDir.listFiles() : []
 
         licenseTask.dependenciesJson = generatedJson
+        licenseTask.thirdPartyLicenses = thirdPartyLicenses
         licenseTask.outputDir = outputDir
         licenseTask.licenses = licensesFile
         licenseTask.licensesMetadata = licensesMetadataFile
 
         licenseTask.inputs.file(generatedJson)
+        licenseTask.inputs.files(thirdPartyLicenses)
         licenseTask.outputs.dir(outputDir)
         licenseTask.outputs.files(licensesFile, licensesMetadataFile)
 


### PR DESCRIPTION
This PR brings in support for 3rd party licenses to be added manually through a `third_party_licenses` directory. Add any text file to that directory, and the name is used in the list (best to avoid adding any file extensions like `.txt`) and the content of the file is shown in the license activity.